### PR TITLE
Use a pointer to result and a WaitGroup instead of channels.

### DIFF
--- a/go/skynet.go
+++ b/go/skynet.go
@@ -1,30 +1,39 @@
 package main
 
-import "fmt"
-import "time"
+import (
+	"fmt"
+	"sync"
+	"time"
+)
 
-func skynet(c chan int, num, size, div int) {
+func skynet(result *int, wg *sync.WaitGroup, num, size, div int) {
 	if size == 1 {
-		c <- num
+		*result = num
 	} else {
-		rc := make(chan int)
+		results := make([]int, div)
 		sum := 0
+		var sub_wg sync.WaitGroup
+		sub_wg.Add(div)
 		for i := 0; i < div; i++ {
 			sub_num := num + i*(size/div)
-			go skynet(rc, sub_num, size/div, div)
+			go skynet(&(results[i]), &sub_wg, sub_num, size/div, div)
 		}
-		for i := 0; i < div; i++ {
-			sum += <-rc
+		sub_wg.Wait()
+		for _, r := range results {
+			sum += r
 		}
-		c <- sum
+		*result = sum
 	}
+	wg.Done()
 }
 
 func main() {
-	c := make(chan int)
+	var result int
+	var wg sync.WaitGroup
+	wg.Add(1)
 	start := time.Now().UnixNano() / 1000000
-	go skynet(c, 0, 1000000, 10)
-	result := <-c
+	go skynet(&result, &wg, 0, 1000000, 10)
+	wg.Wait()
 	end := time.Now().UnixNano() / 1000000
 	fmt.Printf("Result: %d in %d ms.\n", result, end-start)
 }


### PR DESCRIPTION
Seems to shave a few millis off the time on my laptop:

```
➜  go git:(waitgroup) ✗ stats <orig.txt
min 561.0000
max 1021.0000
sum 68944.0000
mean 689.4400
median 689.4400
modes [643]
stdev 76.7395
➜  go git:(waitgroup) ✗ stats <wg.txt
min 461.0000
max 833.0000
sum 61304.0000
mean 613.0400
median 613.0400
modes [638]
stdev 77.5696
```
